### PR TITLE
Plenty of frames are over 16ms. Fix it.

### DIFF
--- a/tagcloudlib/src/main/java/com/moxun/tagcloudlib/view/TagCloudView.java
+++ b/tagcloudlib/src/main/java/com/moxun/tagcloudlib/view/TagCloudView.java
@@ -54,6 +54,7 @@ public class TagCloudView extends ViewGroup implements Runnable, TagsAdapter.OnD
     public static final int MODE_DECELERATE = 1;
     public static final int MODE_UNIFORM = 2;
     public int mode;
+    private int left, right, top, bottom;
 
     private MarginLayoutParams layoutParams;
     private int minSize;    
@@ -216,11 +217,16 @@ public class TagCloudView extends ViewGroup implements Runnable, TagsAdapter.OnD
     }
 
     private void updateChild() {
-        requestLayout();
+        onLayout(false, left,top,right,bottom);
     }
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        left = l; 
+        right = r; 
+        top = t; 
+        bottom = b;
+        
         for (int i = 0; i < getChildCount(); i++) {
             View child = getChildAt(i);
             if (child.getVisibility() != GONE) {


### PR DESCRIPTION
Hi,  通过Profile GPU Rendering看， 部分帧的绘制都超过了16ms。 
追踪代码，发现onMeasure()被调用了多次，而其实我们代码里要实现的是子View的layout的变化，不需要再次重新Measure. 
以此为思路， 找到根源在于requestLayout()方法。 这个方法会让父View重新measure & layout自己。 所以改动一下， 只layout自己的各个子项即可。 

效果图稍后附上~