### PR TITLE
ViewTagsAdapter 空指针

### DIFF
--- a/app/src/main/java/com/moxun/tagcloud/ViewTagsAdapter.java
+++ b/app/src/main/java/com/moxun/tagcloud/ViewTagsAdapter.java
@@ -34,6 +34,9 @@ public class ViewTagsAdapter extends TagsAdapter {
 
     @Override
     public void onThemeColorChanged(View view, int themeColor) {
-        view.findViewById(R.id.android_eye).setBackgroundColor(themeColor);
+		View androidEye = view.findViewById(R.id.android_eye);
+		if (androidEye!=null){
+			androidEye.setBackgroundColor(themeColor);
+		}
     }
 }


### PR DESCRIPTION
将SIMPLE TEXT TAG和CUSTOM VIEW TAG多次切换后程序奔溃
cause:` onThemeColorChanged()`方法中没有进行非空判定